### PR TITLE
cleanup: JOIN-16558 cleanup decorators

### DIFF
--- a/internal/generator/runner_generate.go
+++ b/internal/generator/runner_generate.go
@@ -123,10 +123,6 @@ func (r *Runner) generateTypescriptNamespace(generatedFileStream *protogen.Gener
 	)
 	r.indentLevel += 2
 
-	if r.currentPackage == "google.protobuf" {
-		r.generateTypescriptCommonPackageDecoratorDefinition(generatedFileStream, protoFile)
-	}
-
 	// This interface is namespace-private, as it's being replicated for every generated file
 	r.P(
 		generatedFileStream,
@@ -146,21 +142,6 @@ func (r *Runner) generateTypescriptNamespace(generatedFileStream *protogen.Gener
 	r.currentPackage = ""
 	r.indentLevel -= 2
 	r.P(generatedFileStream, "\n}")
-}
-
-func (r *Runner) generateTypescriptCommonPackageDecoratorDefinition(generatedFileStream *protogen.GeneratedFile, protoFile *protogen.File) {
-	r.P(
-		generatedFileStream,
-		"const registerCommonClass = <T extends protobufjs.Message<T>>(typeName: string): protobufjs.TypeDecorator<T> => {",
-		"  const registeredType = protobufjs.util.decorateRoot.get(typeName)",
-		"  if (registeredType == null) {",
-		"    return protobufjs.Type.d(typeName)",
-		"  }",
-		"  return (ctor: protobufjs.Constructor<T>): void => {",
-		"    Object.defineProperty(ctor, '$type', { value: registeredType, enumerable: false })",
-		"  }",
-		"}",
-	)
 }
 
 func (r *Runner) generateTypescriptFlavors(generatedFileStream *protogen.GeneratedFile, protoFile *protogen.File) {

--- a/internal/generator/runner_generate_class.go
+++ b/internal/generator/runner_generate_class.go
@@ -131,14 +131,9 @@ func (r *Runner) generateTypescriptMessageClass(generatedFileStream *protogen.Ge
 		implementedInterfaces += ", I" + className
 	}
 
-	classDecoratorName := "@protobufjs.Type.d"
-	if r.currentPackage == "google.protobuf" {
-		classDecoratorName = "@registerCommonClass"
-	}
-
 	r.P(
 		generatedFileStream,
-		classDecoratorName+"('"+strings.Replace(r.currentPackage, ".", "_", -1)+"_"+className+"')",
+		"@protobufjs.Type.d('"+strings.Replace(r.currentPackage, ".", "_", -1)+"_"+className+"')",
 		"export class "+className+" extends protobufjs.Message<"+className+"> implements "+implementedInterfaces+" {\n",
 	)
 	r.indentLevel += 2

--- a/tests/__tests__/generated/Flavors.ts
+++ b/tests/__tests__/generated/Flavors.ts
@@ -1,5 +1,5 @@
 // GENERATED CODE -- DO NOT EDIT!
-// GENERATOR VERSION: 2.1.0.d41be8f.1643383265
+// GENERATOR VERSION: 2.1.0.5feef43.1644781028
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as joinGRPC from '@join-com/grpc'

--- a/tests/__tests__/generated/Regressions.ts
+++ b/tests/__tests__/generated/Regressions.ts
@@ -1,5 +1,5 @@
 // GENERATED CODE -- DO NOT EDIT!
-// GENERATOR VERSION: 2.1.0.d41be8f.1643383265
+// GENERATOR VERSION: 2.1.0.5feef43.1644781028
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as protobufjs from 'protobufjs/light'

--- a/tests/__tests__/generated/Test.ts
+++ b/tests/__tests__/generated/Test.ts
@@ -1,5 +1,5 @@
 // GENERATED CODE -- DO NOT EDIT!
-// GENERATOR VERSION: 2.1.0.d41be8f.1643383265
+// GENERATOR VERSION: 2.1.0.5feef43.1644781028
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as joinGRPC from '@join-com/grpc'

--- a/tests/__tests__/generated/common/Common.ts
+++ b/tests/__tests__/generated/common/Common.ts
@@ -1,5 +1,5 @@
 // GENERATED CODE -- DO NOT EDIT!
-// GENERATOR VERSION: 2.1.0.d41be8f.1643383265
+// GENERATOR VERSION: 2.1.0.5feef43.1644781028
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as protobufjs from 'protobufjs/light'

--- a/tests/__tests__/generated/common/Extra.ts
+++ b/tests/__tests__/generated/common/Extra.ts
@@ -1,5 +1,5 @@
 // GENERATED CODE -- DO NOT EDIT!
-// GENERATOR VERSION: 2.1.0.d41be8f.1643383265
+// GENERATOR VERSION: 2.1.0.5feef43.1644781028
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as protobufjs from 'protobufjs/light'

--- a/tests/__tests__/generated/google/protobuf/Empty.ts
+++ b/tests/__tests__/generated/google/protobuf/Empty.ts
@@ -1,27 +1,18 @@
 // GENERATED CODE -- DO NOT EDIT!
-// GENERATOR VERSION: 2.1.0.d41be8f.1643383265
+// GENERATOR VERSION: 2.1.0.5feef43.1644781028
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as protobufjs from 'protobufjs/light'
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace GoogleProtobuf {
-  const registerCommonClass = <T extends protobufjs.Message<T>>(typeName: string): protobufjs.TypeDecorator<T> => {
-    const registeredType = protobufjs.util.decorateRoot.get(typeName)
-    if (registeredType == null) {
-      return protobufjs.Type.d(typeName)
-    }
-    return (ctor: protobufjs.Constructor<T>): void => {
-      Object.defineProperty(ctor, '$type', { value: registeredType, enumerable: false })
-    }
-  }
   interface ConvertibleTo<T> {
     asInterface(): T
   }
 
   export interface IEmpty {}
 
-  @registerCommonClass('google_protobuf_Empty')
+  @protobufjs.Type.d('google_protobuf_Empty')
   export class Empty extends protobufjs.Message<Empty> implements ConvertibleTo<IEmpty>, IEmpty {
     public asInterface(): IEmpty {
       const message = {

--- a/tests/__tests__/generated/google/protobuf/Timestamp.ts
+++ b/tests/__tests__/generated/google/protobuf/Timestamp.ts
@@ -1,20 +1,11 @@
 // GENERATED CODE -- DO NOT EDIT!
-// GENERATOR VERSION: 2.1.0.d41be8f.1643383265
+// GENERATOR VERSION: 2.1.0.5feef43.1644781028
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as protobufjs from 'protobufjs/light'
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace GoogleProtobuf {
-  const registerCommonClass = <T extends protobufjs.Message<T>>(typeName: string): protobufjs.TypeDecorator<T> => {
-    const registeredType = protobufjs.util.decorateRoot.get(typeName)
-    if (registeredType == null) {
-      return protobufjs.Type.d(typeName)
-    }
-    return (ctor: protobufjs.Constructor<T>): void => {
-      Object.defineProperty(ctor, '$type', { value: registeredType, enumerable: false })
-    }
-  }
   interface ConvertibleTo<T> {
     asInterface(): T
   }
@@ -24,7 +15,7 @@ export namespace GoogleProtobuf {
     nanos?: number
   }
 
-  @registerCommonClass('google_protobuf_Timestamp')
+  @protobufjs.Type.d('google_protobuf_Timestamp')
   export class Timestamp extends protobufjs.Message<Timestamp> implements ConvertibleTo<ITimestamp>, ITimestamp {
     @protobufjs.Field.d(1, 'int64', 'optional')
     public seconds?: number

--- a/tests/__tests__/generatedRedundant/Flavors.ts
+++ b/tests/__tests__/generatedRedundant/Flavors.ts
@@ -1,5 +1,5 @@
 // GENERATED CODE -- DO NOT EDIT!
-// GENERATOR VERSION: 2.1.0.d41be8f.1643383265
+// GENERATOR VERSION: 2.1.0.5feef43.1644781028
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as joinGRPC from '@join-com/grpc'

--- a/tests/__tests__/generatedRedundant/Regressions.ts
+++ b/tests/__tests__/generatedRedundant/Regressions.ts
@@ -1,5 +1,5 @@
 // GENERATED CODE -- DO NOT EDIT!
-// GENERATOR VERSION: 2.1.0.d41be8f.1643383265
+// GENERATOR VERSION: 2.1.0.5feef43.1644781028
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as protobufjs from 'protobufjs/light'

--- a/tests/__tests__/generatedRedundant/Test.ts
+++ b/tests/__tests__/generatedRedundant/Test.ts
@@ -1,5 +1,5 @@
 // GENERATED CODE -- DO NOT EDIT!
-// GENERATOR VERSION: 2.1.0.d41be8f.1643383265
+// GENERATOR VERSION: 2.1.0.5feef43.1644781028
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as joinGRPC from '@join-com/grpc'

--- a/tests/__tests__/generatedRedundant/common/Common.ts
+++ b/tests/__tests__/generatedRedundant/common/Common.ts
@@ -1,5 +1,5 @@
 // GENERATED CODE -- DO NOT EDIT!
-// GENERATOR VERSION: 2.1.0.d41be8f.1643383265
+// GENERATOR VERSION: 2.1.0.5feef43.1644781028
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as protobufjs from 'protobufjs/light'

--- a/tests/__tests__/generatedRedundant/common/Extra.ts
+++ b/tests/__tests__/generatedRedundant/common/Extra.ts
@@ -1,5 +1,5 @@
 // GENERATED CODE -- DO NOT EDIT!
-// GENERATOR VERSION: 2.1.0.d41be8f.1643383265
+// GENERATOR VERSION: 2.1.0.5feef43.1644781028
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as protobufjs from 'protobufjs/light'

--- a/tests/__tests__/generatedRedundant/google/protobuf/Empty.ts
+++ b/tests/__tests__/generatedRedundant/google/protobuf/Empty.ts
@@ -1,27 +1,18 @@
 // GENERATED CODE -- DO NOT EDIT!
-// GENERATOR VERSION: 2.1.0.d41be8f.1643383265
+// GENERATOR VERSION: 2.1.0.5feef43.1644781028
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as protobufjs from 'protobufjs/light'
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace GoogleProtobuf {
-  const registerCommonClass = <T extends protobufjs.Message<T>>(typeName: string): protobufjs.TypeDecorator<T> => {
-    const registeredType = protobufjs.util.decorateRoot.get(typeName)
-    if (registeredType == null) {
-      return protobufjs.Type.d(typeName)
-    }
-    return (ctor: protobufjs.Constructor<T>): void => {
-      Object.defineProperty(ctor, '$type', { value: registeredType, enumerable: false })
-    }
-  }
   interface ConvertibleTo<T> {
     asInterface(): T
   }
 
   export interface IEmpty {}
 
-  @registerCommonClass('google_protobuf_Empty')
+  @protobufjs.Type.d('google_protobuf_Empty')
   export class Empty extends protobufjs.Message<Empty> implements ConvertibleTo<IEmpty>, IEmpty {
     public asInterface(): IEmpty {
       const message = {

--- a/tests/__tests__/generatedRedundant/google/protobuf/Timestamp.ts
+++ b/tests/__tests__/generatedRedundant/google/protobuf/Timestamp.ts
@@ -1,20 +1,11 @@
 // GENERATED CODE -- DO NOT EDIT!
-// GENERATOR VERSION: 2.1.0.d41be8f.1643383265
+// GENERATOR VERSION: 2.1.0.5feef43.1644781028
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as protobufjs from 'protobufjs/light'
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace GoogleProtobuf {
-  const registerCommonClass = <T extends protobufjs.Message<T>>(typeName: string): protobufjs.TypeDecorator<T> => {
-    const registeredType = protobufjs.util.decorateRoot.get(typeName)
-    if (registeredType == null) {
-      return protobufjs.Type.d(typeName)
-    }
-    return (ctor: protobufjs.Constructor<T>): void => {
-      Object.defineProperty(ctor, '$type', { value: registeredType, enumerable: false })
-    }
-  }
   interface ConvertibleTo<T> {
     asInterface(): T
   }
@@ -24,7 +15,7 @@ export namespace GoogleProtobuf {
     nanos?: number
   }
 
-  @registerCommonClass('google_protobuf_Timestamp')
+  @protobufjs.Type.d('google_protobuf_Timestamp')
   export class Timestamp extends protobufjs.Message<Timestamp> implements ConvertibleTo<ITimestamp>, ITimestamp {
     @protobufjs.Field.d(1, 'int64', 'optional')
     public seconds?: number

--- a/tests/__tests__/regressions03.test.ts
+++ b/tests/__tests__/regressions03.test.ts
@@ -1,23 +1,31 @@
 // The real test is here: we want to ensure that redundant imports don't cause an error.
-import { GoogleProtobuf as gp1 } from './generated/google/protobuf/Timestamp'
-import { GoogleProtobuf as gp2 } from './generatedRedundant/google/protobuf/Timestamp'
+import { Root, roots } from 'protobufjs'
 
-import { GoogleProtobuf as gp3 } from './generated/google/protobuf/Empty'
+// Required to isolate registered protobuf types between packages.
+// By default a single Root is used to register types which may cause a `duplicate name X in Root` error.
+roots['decorated'] = new Root()
+
+import { GoogleProtobuf as gp1 } from './generated/google/protobuf/Timestamp'
+import { GoogleProtobuf as gp2 } from './generated/google/protobuf/Empty'
+
+// Required to isolate registered protobuf types between packages.
+// By default a single Root is used to register types which may cause a `duplicate name X in Root` error.
+roots['decorated'] = new Root()
+
+import { GoogleProtobuf as gp3 } from './generatedRedundant/google/protobuf/Timestamp'
 import { GoogleProtobuf as gp4 } from './generatedRedundant/google/protobuf/Empty'
 
 describe('regressions 03', () => {
   it('dummy test', () => {
     // This test has code only to ensure that the linters don't complain because of unused imports.
-    const _ts1 = gp1.Timestamp.fromInterface({ seconds: 0, nanos: 0 })
-    const _ts2 = gp2.Timestamp.fromInterface({ seconds: 0, nanos: 0 })
+    const _ts1 = gp1.Timestamp.fromInterface({ seconds: 1, nanos: 2 })
+    const _ts3 = gp3.Timestamp.fromInterface({ seconds: 1, nanos: 2 })
+    expect(_ts1.asInterface().seconds).toEqual(_ts3.asInterface().seconds)
+    expect(_ts1.asInterface().nanos).toEqual(_ts3.asInterface().nanos)
 
-    expect(_ts1.asInterface().seconds).toEqual(_ts2.asInterface().seconds)
-    expect(_ts1.asInterface().nanos).toEqual(_ts2.asInterface().nanos)
-
-    const _ts3 = gp3.Empty.fromInterface({})
+    const _ts2 = gp2.Empty.fromInterface({})
     const _ts4 = gp4.Empty.fromInterface({ seconds: 0, nanos: 0 })
-
-    expect(_ts3.asInterface()).toEqual({})
+    expect(_ts2.asInterface()).toEqual({})
     expect(_ts4.asInterface()).toEqual({})
   })
 })


### PR DESCRIPTION
A custom decorator does not help to resolve the issue of duplicated types. It still appears when the third package with Timestamp class is imported.

An alternative solution is to set a new Root instance before first client package import
```ts
roots['decorated'] = new Root
```